### PR TITLE
Added support for more sensortype names. Kävlinge uses Matavfall and …

### DIFF
--- a/custom_components/sysav/manifest.json
+++ b/custom_components/sysav/manifest.json
@@ -5,6 +5,6 @@
   "documentation": "https://github.com/sebbebebbe/sysav.sensor",
   "domain": "sysav",
   "name": "Sysav waste gathering sensor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "requirements": []
 }

--- a/custom_components/sysav/sensor.py
+++ b/custom_components/sysav/sensor.py
@@ -53,6 +53,8 @@ ATTR_LAST_UPDATE = "Last update"
 SENSOR_TYPES = {
     "Kärl 1": ["Kärl 1", "", "mdi:delete"],
     "Kärl 2": ["Kärl 2", "", "mdi:delete"],
+    "Matavfall": ["Matavfall", "", "mdi:delete"],
+    "Restavfall": ["Restavfall", "", "mdi:delete"],
     "Trädgårdsavfall": ["Trädgårdsavfall", "", "mdi:delete"],
 }
 


### PR DESCRIPTION
…Restavfall instead of Kärl 1 and Kärl 2